### PR TITLE
add vary header to prevent browsers from caching a json response

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -15,6 +15,7 @@ server {
         }
 
         try_files $uri $uri/ /index.html?/$request_uri;	
+        add_header Vary "X-Requested-With, Content-Type";
     }
 
     location ~ STATIC_FOLDERS_REGEX {


### PR DESCRIPTION
this prevents browsers from caching a json response when the json is requested before a page is rendered at the url (still need to this :))