### PR TITLE
enable gzip on common mime types

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -31,5 +31,8 @@ server {
         proxy_pass http://backend_app;
     }
 
+    gzip on;
+    gzip_types text/html application/json application/vnd.api+json application/javascript text/css;
+
     include /config/*.conf;
 }


### PR DESCRIPTION
- The mu.semte.ch stack has a bunch of things that are cheap to gzip.
- our javascript files can get quite big

This should improve initial load of the SPA.