### PR TITLE
pass original hostname in X-Forwarded-Host

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -26,7 +26,7 @@ server {
 
     location @backend {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-Host $http_host;
         proxy_redirect off;
         proxy_pass http://backend_app;
     }


### PR DESCRIPTION
This PR proposes to set the X-Forwarded-Host header instead of the Host header (which is overwritten by identifier and dispatcher later on in the chain). To quote [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host):
>The X-Forwarded-Host (XFH) header is a de-facto standard header for identifying the original host requested by the client in the Host HTTP request header.

>Host names and ports of reverse proxies (load balancers, CDNs) may differ from the origin server handling the request, in that case the X-Forwarded-Host header is useful to determine which Host was originally used.