### PR TITLE
Escape slashes before using sed in environment var

### DIFF
--- a/ember-proxy-service.sh
+++ b/ember-proxy-service.sh
@@ -10,7 +10,7 @@ ENV_VARIABLES=$(env | grep "${PREFIX}")
 
 while IFS= read -r line; do
   ENV_VARIABLE=$(echo "$line" | sed -e "s/^$PREFIX//" | cut -f1 -d"=")
-  VALUE=$(echo "$line" | cut -d"=" -f2-)
+  VALUE=$(echo "$line" | sed -e 's/[\/&]/\\&/g' | cut -d"=" -f2-)
   sed -i "s/%7B%7B$ENV_VARIABLE%7D%7D/$VALUE/g" /app/index.html
   sed -i "s/{{$ENV_VARIABLE}}/$VALUE/g" /app/index.html
 done <<< "$ENV_VARIABLES"


### PR DESCRIPTION
When replacing environment variables with sed, if the variable contains the character `/`, sed is confused because it's the same character as its delimiter. Escaping `/` in the variables before using sed allows it to replace the variables smoothly.